### PR TITLE
Recover unconfigured controllers in ControllerStopper

### DIFF
--- a/eli_cs_robot_driver/CMakeLists.txt
+++ b/eli_cs_robot_driver/CMakeLists.txt
@@ -233,6 +233,17 @@ if(BUILD_TESTING)
   ament_add_gtest(test_rt_memory_reporting test/test_rt_memory_reporting.cpp)
   target_include_directories(test_rt_memory_reporting PRIVATE include)
 
+  # Regression tests for ControllerStopper's restart path (configure-before-activate and
+  # BEST_EFFORT strictness). Drives the real class against a fake controller manager, so it
+  # links controller_stopper.cpp and needs rclcpp.
+  ament_add_gtest(test_controller_stopper test/test_controller_stopper.cpp src/controller_stopper.cpp)
+  target_include_directories(test_controller_stopper PRIVATE include)
+  ament_target_dependencies(
+    test_controller_stopper
+    ${${PROJECT_NAME}_EXPORTED_TARGETS}
+    ${THIS_PACKAGE_DEPENDENCIES}
+  )
+
   # Regression test for elite_control.launch.py's bool-typed launch parameters.
   find_package(ament_cmake_pytest REQUIRED)
   ament_add_pytest_test(test_elite_control_launch test/test_elite_control_launch.py)

--- a/eli_cs_robot_driver/include/eli_cs_robot_driver/controller_stopper.hpp
+++ b/eli_cs_robot_driver/include/eli_cs_robot_driver/controller_stopper.hpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include <controller_manager_msgs/srv/configure_controller.hpp>
 #include <controller_manager_msgs/srv/list_controllers.hpp>
 #include <controller_manager_msgs/srv/switch_controller.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -33,12 +34,29 @@ class ControllerStopper {
     /*!
      * \brief Starts the controllers stored in stopped_controllers_.
      *
+     * A controller can only be activated from the 'inactive' state. Anything that resets the
+     * hardware interfaces underneath a controller (e.g. cycling the hardware component after a
+     * driver reset) drops it all the way back to 'unconfigured', where it can never be activated
+     * again. So this first queries the current state of every stopped controller and configures
+     * the unconfigured ones, then activates. See activateStoppedControllers().
      */
     void startControllers();
+
+    /*!
+     * \brief Activates the controllers stored in stopped_controllers_ with BEST_EFFORT strictness.
+     *
+     * Called once every controller in stopped_controllers_ that needed configuring has been
+     * configured. BEST_EFFORT (rather than STRICT) so that a single controller that cannot be
+     * brought back -- unloaded, still unconfigured, hardware interface unavailable -- does not
+     * cause the controller manager to reject the switch wholesale and leave every other
+     * controller stopped too.
+     */
+    void activateStoppedControllers();
 
     std::shared_ptr<rclcpp::Node> node_;
     rclcpp::Client<controller_manager_msgs::srv::SwitchController>::SharedPtr controller_manager_srv_;
     rclcpp::Client<controller_manager_msgs::srv::ListControllers>::SharedPtr controller_list_srv_;
+    rclcpp::Client<controller_manager_msgs::srv::ConfigureController>::SharedPtr configure_controller_srv_;
     rclcpp::Client<eli_common_interface::srv::GetRobotMode>::SharedPtr dashboard_robot_mode_srv_;
 
     rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr robot_running_sub_;

--- a/eli_cs_robot_driver/src/controller_stopper.cpp
+++ b/eli_cs_robot_driver/src/controller_stopper.cpp
@@ -1,3 +1,5 @@
+#include <atomic>
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -23,6 +25,10 @@ ControllerStopper::ControllerStopper(const rclcpp::Node::SharedPtr& node, bool s
     controller_list_srv_ = node_->create_client<controller_manager_msgs::srv::ListControllers>(
         "controller_manager/"
         "list_controllers");
+    // Controller manager service to configure controllers (unconfigured -> inactive)
+    configure_controller_srv_ = node_->create_client<controller_manager_msgs::srv::ConfigureController>(
+        "controller_manager/"
+        "configure_controller");
 
     // Get robot mode from dashboard
     dashboard_robot_mode_srv_ = node->create_client<eli_common_interface::srv::GetRobotMode>("dashboard_client/robot_mode");
@@ -39,6 +45,13 @@ ControllerStopper::ControllerStopper(const rclcpp::Node::SharedPtr& node, bool s
                 "Waiting for list controllers service to come up on "
                 "controller_manager/list_controllers");
     controller_list_srv_->wait_for_service();
+    RCLCPP_INFO(rclcpp::get_logger("Controller stopper"), "Service available");
+
+    // Wait "controller_manager/configure_controller"
+    RCLCPP_INFO(rclcpp::get_logger("Controller stopper"),
+                "Waiting for configure controller service to come up on "
+                "controller_manager/configure_controller");
+    configure_controller_srv_->wait_for_service();
     RCLCPP_INFO(rclcpp::get_logger("Controller stopper"), "Service available");
 
     // Wait "dashboard_client/robot_mode"
@@ -82,7 +95,9 @@ ControllerStopper::ControllerStopper(const rclcpp::Node::SharedPtr& node, bool s
             rclcpp::sleep_for(std::chrono::milliseconds(100));
         }
         auto request_switch_controller = std::make_shared<controller_manager_msgs::srv::SwitchController::Request>();
-        request_switch_controller->strictness = request_switch_controller->STRICT;
+        // BEST_EFFORT: one controller that cannot be deactivated must not abort the whole switch
+        // and leave the rest running while the robot program is not.
+        request_switch_controller->strictness = request_switch_controller->BEST_EFFORT;
         request_switch_controller->deactivate_controllers = stopped_controllers_;
         auto future = controller_manager_srv_->async_send_request(request_switch_controller);
         rclcpp::spin_until_future_complete(node_, future);
@@ -123,7 +138,8 @@ void ControllerStopper::findAndStopControllers() {
                     }
                 }
             }
-            request_switch_controller->strictness = request_switch_controller->STRICT;
+            // BEST_EFFORT: see the constructor's startup deactivation for why.
+            request_switch_controller->strictness = request_switch_controller->BEST_EFFORT;
             if (!stopped_controllers_.empty()) {
                 request_switch_controller->deactivate_controllers = stopped_controllers_;
                 auto future = controller_manager_srv_->async_send_request(request_switch_controller, callback_switch_controller);
@@ -134,7 +150,68 @@ void ControllerStopper::findAndStopControllers() {
 }
 
 void ControllerStopper::startControllers() {
-    // Callback to switch controllers
+    if (stopped_controllers_.empty()) {
+        return;
+    }
+
+    // A controller can only be activated out of the 'inactive' state. Anything that resets the
+    // hardware interfaces underneath a controller -- notably cycling the cs612 hardware component,
+    // which a driver reset does -- drops that controller back to 'unconfigured' instead. Activating
+    // it from there is impossible, so re-query the current states first and configure whatever came
+    // back unconfigured before attempting the switch. Without this the controller is stranded
+    // permanently: nothing else ever reconfigures it, and every subsequent robot-program cycle
+    // retries the same impossible activation.
+    auto request_list_controllers = std::make_shared<controller_manager_msgs::srv::ListControllers::Request>();
+
+    auto callback_list_controller =
+        [this](rclcpp::Client<controller_manager_msgs::srv::ListControllers>::SharedFuture future_response) {
+            auto result = future_response.get();
+            std::map<std::string, std::string> state_by_name;
+            for (const auto& controller : result->controller) {
+                state_by_name[controller.name] = controller.state;
+            }
+
+            std::vector<std::string> to_configure;
+            for (const auto& name : stopped_controllers_) {
+                auto it = state_by_name.find(name);
+                if (it != state_by_name.end() && it->second == "unconfigured") {
+                    to_configure.push_back(name);
+                }
+            }
+
+            if (to_configure.empty()) {
+                activateStoppedControllers();
+                return;
+            }
+
+            // Activate only once every configure request has come back, otherwise the switch would
+            // race the transitions it depends on. Configure failures are logged and then ignored --
+            // BEST_EFFORT activation will simply skip anything still unconfigured.
+            auto pending = std::make_shared<std::atomic<size_t>>(to_configure.size());
+            for (const auto& name : to_configure) {
+                RCLCPP_WARN(rclcpp::get_logger("Controller stopper"),
+                            "Controller '%s' is unconfigured; configuring it before activation", name.c_str());
+                auto request = std::make_shared<controller_manager_msgs::srv::ConfigureController::Request>();
+                request->name = name;
+                // `name` captured by value: the lambda outlives this loop iteration.
+                configure_controller_srv_->async_send_request(
+                    request, [this, pending, name](
+                                 rclcpp::Client<controller_manager_msgs::srv::ConfigureController>::SharedFuture future) {
+                        if (future.get()->ok == false) {
+                            RCLCPP_ERROR(rclcpp::get_logger("Controller stopper"), "Could not configure controller '%s'",
+                                         name.c_str());
+                        }
+                        if (pending->fetch_sub(1) == 1) {
+                            activateStoppedControllers();
+                        }
+                    });
+            }
+        };
+
+    auto future = controller_list_srv_->async_send_request(request_list_controllers, callback_list_controller);
+}
+
+void ControllerStopper::activateStoppedControllers() {
     auto callback = [this](rclcpp::Client<controller_manager_msgs::srv::SwitchController>::SharedFuture future_response) {
         auto result = future_response.get();
         if (result->ok == false) {
@@ -143,7 +220,11 @@ void ControllerStopper::startControllers() {
     };
     if (!stopped_controllers_.empty()) {
         auto request = std::make_shared<controller_manager_msgs::srv::SwitchController::Request>();
-        request->strictness = request->STRICT;
+        // BEST_EFFORT: a controller that still cannot be activated (unloaded, configure failed,
+        // hardware interface unavailable) must not take every other stopped controller down with
+        // it. Under STRICT the controller manager rejects the entire switch, so one stranded
+        // controller blocks the robot indefinitely.
+        request->strictness = request->BEST_EFFORT;
         request->activate_controllers = stopped_controllers_;
         auto future = controller_manager_srv_->async_send_request(request, callback);
     }

--- a/eli_cs_robot_driver/test/test_controller_stopper.cpp
+++ b/eli_cs_robot_driver/test/test_controller_stopper.cpp
@@ -1,0 +1,339 @@
+// Regression tests for ControllerStopper's restart path.
+//
+// Field failure these cover: cycling the cs612 hardware component (which a driver reset does)
+// drops controllers that claim its interfaces from 'inactive' all the way back to 'unconfigured'.
+// ControllerStopper used to re-activate its captured stopped_controllers_ list with STRICT
+// strictness and no configure step, so:
+//   1. the unconfigured controller could never be activated (STRICT or not, activation is only
+//      legal from 'inactive'), and
+//   2. under STRICT the controller manager rejected the *entire* switch, so every other stopped
+//      controller stayed stopped too.
+// Nothing ever reconfigured the stranded controller, so every subsequent robot-program cycle
+// retried the same impossible switch and the arm never recovered without manual intervention.
+//
+// These tests drive the real ControllerStopper against a fake controller manager that models the
+// controller lifecycle (unconfigured -> inactive -> active) and the STRICT/BEST_EFFORT switch
+// semantics, then assert on the requests it actually issued.
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <controller_manager_msgs/srv/configure_controller.hpp>
+#include <controller_manager_msgs/srv/list_controllers.hpp>
+#include <controller_manager_msgs/srv/switch_controller.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/bool.hpp>
+
+#include "eli_common_interface/msg/robot_mode.hpp"
+#include "eli_common_interface/srv/get_robot_mode.hpp"
+#include "eli_cs_robot_driver/controller_stopper.hpp"
+
+using namespace std::chrono_literals;
+
+using ConfigureController = controller_manager_msgs::srv::ConfigureController;
+using GetRobotMode = eli_common_interface::srv::GetRobotMode;
+using ListControllers = controller_manager_msgs::srv::ListControllers;
+using SwitchController = controller_manager_msgs::srv::SwitchController;
+
+namespace {
+
+constexpr char kJointStateBroadcaster[] = "joint_state_broadcaster";
+constexpr char kAdmittanceController[] = "joint_trajectory_admittance_controller";
+constexpr char kForwardPositionController[] = "forward_position_controller";
+
+/// One switch_controller request as ControllerStopper issued it.
+struct SwitchRequest {
+    std::vector<std::string> activate;
+    std::vector<std::string> deactivate;
+    int32_t strictness;
+};
+
+/// Fake controller_manager + dashboard, good enough to exercise the lifecycle rules
+/// ControllerStopper depends on. Spun on its own executor thread so ControllerStopper can block on
+/// wait_for_service()/spin_until_future_complete() from the test thread during construction.
+class FakeControllerManager {
+   public:
+    FakeControllerManager() : node_(std::make_shared<rclcpp::Node>("fake_controller_manager")) {
+        list_srv_ = node_->create_service<ListControllers>(
+            "controller_manager/list_controllers",
+            [this](const ListControllers::Request::SharedPtr, ListControllers::Response::SharedPtr response) {
+                std::lock_guard<std::mutex> lock(mutex_);
+                for (const auto& [name, state] : states_) {
+                    controller_manager_msgs::msg::ControllerState controller;
+                    controller.name = name;
+                    controller.state = state;
+                    response->controller.push_back(controller);
+                }
+            });
+
+        switch_srv_ = node_->create_service<SwitchController>(
+            "controller_manager/switch_controller",
+            [this](const SwitchController::Request::SharedPtr request, SwitchController::Response::SharedPtr response) {
+                std::lock_guard<std::mutex> lock(mutex_);
+                switch_requests_.push_back(
+                    SwitchRequest{request->activate_controllers, request->deactivate_controllers, request->strictness});
+
+                // STRICT: reject the whole switch if any requested transition is illegal, changing
+                // nothing. This is what stranded the arm in the field.
+                if (request->strictness == SwitchController::Request::STRICT) {
+                    for (const auto& name : request->activate_controllers) {
+                        if (states_[name] != "inactive") {
+                            response->ok = false;
+                            return;
+                        }
+                    }
+                    for (const auto& name : request->deactivate_controllers) {
+                        if (states_[name] != "active") {
+                            response->ok = false;
+                            return;
+                        }
+                    }
+                }
+
+                // BEST_EFFORT (and a legal STRICT switch): apply what is legal, skip what is not.
+                for (const auto& name : request->activate_controllers) {
+                    if (states_[name] == "inactive") {
+                        states_[name] = "active";
+                    }
+                }
+                for (const auto& name : request->deactivate_controllers) {
+                    if (states_[name] == "active") {
+                        states_[name] = "inactive";
+                    }
+                }
+                response->ok = true;
+            });
+
+        configure_srv_ = node_->create_service<ConfigureController>(
+            "controller_manager/configure_controller",
+            [this](const ConfigureController::Request::SharedPtr request,
+                   ConfigureController::Response::SharedPtr response) {
+                std::lock_guard<std::mutex> lock(mutex_);
+                configure_requests_.push_back(request->name);
+                if (configure_should_fail_) {
+                    response->ok = false;
+                    return;
+                }
+                if (states_[request->name] == "unconfigured") {
+                    states_[request->name] = "inactive";
+                }
+                response->ok = true;
+            });
+
+        robot_mode_srv_ = node_->create_service<GetRobotMode>(
+            "dashboard_client/robot_mode",
+            [](const GetRobotMode::Request::SharedPtr, GetRobotMode::Response::SharedPtr response) {
+                response->mode.mode = eli_common_interface::msg::RobotMode::RUNNING;
+            });
+
+        executor_.add_node(node_);
+        thread_ = std::thread([this]() { executor_.spin(); });
+    }
+
+    ~FakeControllerManager() {
+        executor_.cancel();
+        if (thread_.joinable()) {
+            thread_.join();
+        }
+    }
+
+    void setState(const std::string& name, const std::string& state) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        states_[name] = state;
+    }
+
+    std::string state(const std::string& name) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return states_[name];
+    }
+
+    void setConfigureShouldFail(bool should_fail) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        configure_should_fail_ = should_fail;
+    }
+
+    std::vector<SwitchRequest> switchRequests() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return switch_requests_;
+    }
+
+    std::vector<std::string> configureRequests() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return configure_requests_;
+    }
+
+   private:
+    rclcpp::Node::SharedPtr node_;
+    rclcpp::Service<ListControllers>::SharedPtr list_srv_;
+    rclcpp::Service<SwitchController>::SharedPtr switch_srv_;
+    rclcpp::Service<ConfigureController>::SharedPtr configure_srv_;
+    rclcpp::Service<GetRobotMode>::SharedPtr robot_mode_srv_;
+    rclcpp::executors::MultiThreadedExecutor executor_;
+    std::thread thread_;
+
+    std::mutex mutex_;
+    std::map<std::string, std::string> states_;
+    std::vector<SwitchRequest> switch_requests_;
+    std::vector<std::string> configure_requests_;
+    bool configure_should_fail_ = false;
+};
+
+/// Poll `predicate` until it holds or the timeout expires. Returns whether it held.
+template <typename Predicate>
+bool waitFor(Predicate predicate, std::chrono::milliseconds timeout = 5s) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (predicate()) {
+            return true;
+        }
+        std::this_thread::sleep_for(10ms);
+    }
+    return predicate();
+}
+
+class ControllerStopperTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        fake_ = std::make_unique<FakeControllerManager>();
+        // The consistent controller stays up across robot-program cycles; the other two are the
+        // ones ControllerStopper captures and must bring back.
+        fake_->setState(kJointStateBroadcaster, "active");
+        fake_->setState(kAdmittanceController, "active");
+        fake_->setState(kForwardPositionController, "active");
+
+        rclcpp::NodeOptions options;
+        options.parameter_overrides(
+            {rclcpp::Parameter("consistent_controllers", std::vector<std::string>{kJointStateBroadcaster})});
+        node_ = std::make_shared<rclcpp::Node>("controller_stopper_under_test", options);
+
+        robot_running_pub_ = node_->create_publisher<std_msgs::msg::Bool>("io_and_status_controller/robot_task_running", 1);
+
+        // Construct before spinning: the constructor drives its own spin_until_future_complete().
+        stopper_ = std::make_unique<ControllerStopper>(node_, /*stop_controllers_on_startup=*/false);
+
+        executor_.add_node(node_);
+        spin_thread_ = std::thread([this]() { executor_.spin(); });
+
+        // ControllerStopper only reacts to *changes*, and starts believing the robot is running.
+        ASSERT_TRUE(waitFor([this]() { return robot_running_pub_->get_subscription_count() > 0; }));
+    }
+
+    void TearDown() override {
+        executor_.cancel();
+        if (spin_thread_.joinable()) {
+            spin_thread_.join();
+        }
+        stopper_.reset();
+        node_.reset();
+        fake_.reset();
+    }
+
+    void publishRobotRunning(bool running) {
+        std_msgs::msg::Bool msg;
+        msg.data = running;
+        robot_running_pub_->publish(msg);
+    }
+
+    /// Drive a full stop cycle so ControllerStopper captures the two non-consistent controllers.
+    void stopControllers() {
+        publishRobotRunning(false);
+        ASSERT_TRUE(waitFor([this]() {
+            return fake_->state(kAdmittanceController) == "inactive" &&
+                   fake_->state(kForwardPositionController) == "inactive";
+        })) << "controllers were never deactivated";
+    }
+
+    std::unique_ptr<FakeControllerManager> fake_;
+    rclcpp::Node::SharedPtr node_;
+    rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr robot_running_pub_;
+    std::unique_ptr<ControllerStopper> stopper_;
+    rclcpp::executors::SingleThreadedExecutor executor_;
+    std::thread spin_thread_;
+};
+
+// --- the field regression ----------------------------------------------------
+
+TEST_F(ControllerStopperTest, ConfiguresAnUnconfiguredControllerBeforeActivatingIt) {
+    stopControllers();
+
+    // A hardware-component cycle (driver reset) knocks the admittance controller past 'inactive'
+    // all the way back to 'unconfigured' while the robot program is stopped.
+    fake_->setState(kAdmittanceController, "unconfigured");
+
+    publishRobotRunning(true);
+
+    ASSERT_TRUE(waitFor([this]() { return fake_->state(kAdmittanceController) == "active"; }))
+        << "unconfigured controller was never recovered -- it must be configured before activation";
+
+    const auto configured = fake_->configureRequests();
+    EXPECT_NE(std::find(configured.begin(), configured.end(), kAdmittanceController), configured.end())
+        << "expected a configure_controller request for the unconfigured controller";
+}
+
+TEST_F(ControllerStopperTest, OneUnrecoverableControllerDoesNotBlockTheOthers) {
+    stopControllers();
+
+    // The admittance controller is unconfigured *and* cannot be configured (e.g. its hardware
+    // interfaces are still unavailable). Everything else must still come back.
+    fake_->setState(kAdmittanceController, "unconfigured");
+    fake_->setConfigureShouldFail(true);
+
+    publishRobotRunning(true);
+
+    ASSERT_TRUE(waitFor([this]() { return fake_->state(kForwardPositionController) == "active"; }))
+        << "a controller that could not be recovered blocked activation of every other controller";
+    EXPECT_EQ(fake_->state(kAdmittanceController), "unconfigured");
+}
+
+// --- strictness --------------------------------------------------------------
+
+TEST_F(ControllerStopperTest, ActivationUsesBestEffortStrictness) {
+    stopControllers();
+    publishRobotRunning(true);
+
+    ASSERT_TRUE(waitFor([this]() { return fake_->state(kAdmittanceController) == "active"; }));
+
+    bool saw_activation = false;
+    for (const auto& request : fake_->switchRequests()) {
+        if (request.activate.empty()) {
+            continue;
+        }
+        saw_activation = true;
+        EXPECT_EQ(request.strictness, SwitchController::Request::BEST_EFFORT)
+            << "STRICT activation lets one stranded controller reject the whole switch";
+    }
+    EXPECT_TRUE(saw_activation) << "no activation switch was ever issued";
+}
+
+TEST_F(ControllerStopperTest, DeactivationUsesBestEffortStrictness) {
+    stopControllers();
+
+    bool saw_deactivation = false;
+    for (const auto& request : fake_->switchRequests()) {
+        if (request.deactivate.empty()) {
+            continue;
+        }
+        saw_deactivation = true;
+        EXPECT_EQ(request.strictness, SwitchController::Request::BEST_EFFORT)
+            << "STRICT deactivation leaves controllers running when the robot program has stopped";
+    }
+    EXPECT_TRUE(saw_deactivation) << "no deactivation switch was ever issued";
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    rclcpp::init(argc, argv);
+    const int result = RUN_ALL_TESTS();
+    rclcpp::shutdown();
+    return result;
+}


### PR DESCRIPTION
> Cycling a hardware component -- which a driver reset does -- drops the controllers claiming its interfaces from 'inactive' all the way back to 'unconfigured'. startControllers() re-activated its captured stopped_controllers_ list with STRICT strictness and no configure step, so the stranded controller could never be activated (activation is only legal from 'inactive'), and under STRICT the controller manager rejected the entire switch -- taking every other stopped controller down with it. Nothing ever reconfigured the controller, so each subsequent robot-task cycle retried the same impossible switch.
> 
> Observed on unit-22 as joint_trajectory_admittance_controller sitting unconfigured indefinitely with nothing serving
> /joint_trajectory_admittance_controller/follow_joint_trajectory, so every arm trajectory goal was rejected until the driver was reset by hand. This is the third controller_stopper_node defect found in the same area, after the startup crash (e4881dc) and freedrive_controller's absence from consistent_controllers (b8da529) -- the node had been dead since launch before those, so none of this enforcement logic had actually run in anger until recently.
> 
> startControllers() now re-queries controller states, issues configure_controller for anything that came back unconfigured, and activates only once every configure has returned (extracted into activateStoppedControllers()). Both deactivation paths and the activation switch use BEST_EFFORT instead of STRICT, so one controller that cannot be transitioned no longer aborts the switch for all the others.
> 
> Add test_controller_stopper.cpp, which drives the real ControllerStopper against a fake controller manager modelling the unconfigured -> inactive -> active lifecycle and both strictness semantics. It covers the regression itself (an unconfigured controller is configured, then activated), the collateral damage (an unrecoverable controller no longer blocks the rest), and the strictness of both the activation and deactivation switches. Reverting the fix fails all four.