### PR TITLE
fix(moveit): integrate MoveIt Pro 9 driver changes

### DIFF
--- a/eli_cs_controllers/include/eli_cs_controllers/freedrive_controller.hpp
+++ b/eli_cs_controllers/include/eli_cs_controllers/freedrive_controller.hpp
@@ -1,7 +1,7 @@
 #ifndef __ELITE_CS_CONTROLLERS_FREEDRIVE_CONTROLLER_HPP__
 #define __ELITE_CS_CONTROLLERS_FREEDRIVE_CONTROLLER_HPP__
 
-#include <freedrive_controller_parameters.hpp>
+#include <eli_cs_controllers/freedrive_controller_parameters.hpp>
 
 #include <atomic>
 #include <controller_interface/controller_interface.hpp>

--- a/eli_cs_controllers/include/eli_cs_controllers/gpio_controller.hpp
+++ b/eli_cs_controllers/include/eli_cs_controllers/gpio_controller.hpp
@@ -16,7 +16,7 @@
 
 #include <std_srvs/srv/trigger.hpp>
 #include <controller_interface/controller_interface.hpp>
-#include <gpio_controller_parameters.hpp>
+#include <eli_cs_controllers/gpio_controller_parameters.hpp>
 #include <rclcpp/duration.hpp>
 #include <rclcpp/time.hpp>
 #include <std_msgs/msg/bool.hpp>

--- a/eli_cs_controllers/include/eli_cs_controllers/scaled_joint_trajectory_controller.hpp
+++ b/eli_cs_controllers/include/eli_cs_controllers/scaled_joint_trajectory_controller.hpp
@@ -7,7 +7,7 @@
 #include "rclcpp/duration.hpp"
 #include "rclcpp/time.hpp"
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
-#include "scaled_joint_trajectory_controller_parameters.hpp"
+#include <eli_cs_controllers/scaled_joint_trajectory_controller_parameters.hpp>
 
 namespace ELITE_CS_CONTROLLER {
 class ScaledJointTrajectoryController : public joint_trajectory_controller::JointTrajectoryController {

--- a/eli_cs_controllers/include/eli_cs_controllers/speed_scaling_state_broadcaster.hpp
+++ b/eli_cs_controllers/include/eli_cs_controllers/speed_scaling_state_broadcaster.hpp
@@ -10,7 +10,7 @@
 #include "rclcpp/time.hpp"
 #include "rclcpp_lifecycle/lifecycle_publisher.hpp"
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
-#include "speed_scaling_state_broadcaster_parameters.hpp"
+#include <eli_cs_controllers/speed_scaling_state_broadcaster_parameters.hpp>
 #include "std_msgs/msg/float64.hpp"
 
 namespace ELITE_CS_CONTROLLER {

--- a/eli_cs_controllers/src/scaled_joint_trajectory_controller.cpp
+++ b/eli_cs_controllers/src/scaled_joint_trajectory_controller.cpp
@@ -70,7 +70,7 @@ controller_interface::return_type ScaledJointTrajectoryController::update(const 
     auto current_external_msg = traj_external_point_ptr_->get_trajectory_msg();
     auto new_external_msg = traj_msg_external_point_ptr_.readFromRT();
     // Discard, if a goal is pending but still not active (somewhere stuck in goal_handle_timer_)
-    if (current_external_msg != *new_external_msg && (*(rt_has_pending_goal_.readFromRT()) && !active_goal) == false) {
+    if (current_external_msg != *new_external_msg && (rt_has_pending_goal_.load() && !active_goal) == false) {
         fill_partial_goal(*new_external_msg);
         sort_to_local_joint_order(*new_external_msg);
         // TODO(denis): Add here integration of position and velocity
@@ -126,7 +126,7 @@ controller_interface::return_type ScaledJointTrajectoryController::update(const 
 
             // have we reached the end, are not holding position, and is a timeout configured?
             // Check independently of other tolerances
-            if (!before_last_point && *(rt_is_holding_.readFromRT()) == false && cmd_timeout_ > 0.0 &&
+            if (!before_last_point && rt_is_holding_.load() == false && cmd_timeout_ > 0.0 &&
                 time_difference > cmd_timeout_) {
                 RCLCPP_WARN(get_node()->get_logger(), "Aborted due to command timeout");
 
@@ -142,13 +142,13 @@ controller_interface::return_type ScaledJointTrajectoryController::update(const 
                 // is the last point
                 if ((before_last_point || first_sample) &&
                     !check_state_tolerance_per_joint(state_error_, index, default_tolerances_.state_tolerance[index], false) &&
-                    *(rt_is_holding_.readFromRT()) == false) {
+                    rt_is_holding_.load() == false) {
                     tolerance_violated_while_moving = true;
                 }
                 // past the final point, check that we end up inside goal tolerance
                 if (!before_last_point &&
                     !check_state_tolerance_per_joint(state_error_, index, default_tolerances_.goal_state_tolerance[index], false) &&
-                    *(rt_is_holding_.readFromRT()) == false) {
+                    rt_is_holding_.load() == false) {
                     outside_goal_tolerance = true;
 
                     if (default_tolerances_.goal_time_tolerance != 0.0) {
@@ -211,7 +211,7 @@ controller_interface::return_type ScaledJointTrajectoryController::update(const 
                     // TODO(matthew-reynolds): Need a lock-free write here
                     // See https://github.com/ros-controls/ros2_controllers/issues/168
                     rt_active_goal_.writeFromNonRT(RealtimeGoalHandlePtr());
-                    rt_has_pending_goal_.writeFromNonRT(false);
+                    rt_has_pending_goal_ = false;
 
                     RCLCPP_WARN(get_node()->get_logger(), "Aborted due to state tolerance violation");
 
@@ -225,7 +225,7 @@ controller_interface::return_type ScaledJointTrajectoryController::update(const 
                         // TODO(matthew-reynolds): Need a lock-free write here
                         // See https://github.com/ros-controls/ros2_controllers/issues/168
                         rt_active_goal_.writeFromNonRT(RealtimeGoalHandlePtr());
-                        rt_has_pending_goal_.writeFromNonRT(false);
+                        rt_has_pending_goal_ = false;
 
                         RCLCPP_INFO(get_node()->get_logger(), "Goal reached, success!");
 
@@ -238,7 +238,7 @@ controller_interface::return_type ScaledJointTrajectoryController::update(const 
                         // TODO(matthew-reynolds): Need a lock-free write here
                         // See https://github.com/ros-controls/ros2_controllers/issues/168
                         rt_active_goal_.writeFromNonRT(RealtimeGoalHandlePtr());
-                        rt_has_pending_goal_.writeFromNonRT(false);
+                        rt_has_pending_goal_ = false;
 
                         RCLCPP_WARN(get_node()->get_logger(), "Aborted due goal_time_tolerance exceeding by %f seconds",
                                     time_difference);
@@ -247,13 +247,13 @@ controller_interface::return_type ScaledJointTrajectoryController::update(const 
                         traj_msg_external_point_ptr_.initRT(set_hold_position());
                     }
                 }
-            } else if (tolerance_violated_while_moving && *(rt_has_pending_goal_.readFromRT()) == false) {
+            } else if (tolerance_violated_while_moving && rt_has_pending_goal_.load() == false) {
                 // we need to ensure that there is no pending goal -> we get a race condition otherwise
                 RCLCPP_ERROR(get_node()->get_logger(), "Holding position due to state tolerance violation");
 
                 traj_msg_external_point_ptr_.reset();
                 traj_msg_external_point_ptr_.initRT(set_hold_position());
-            } else if (!before_last_point && !within_goal_time && *(rt_has_pending_goal_.readFromRT()) == false) {
+            } else if (!before_last_point && !within_goal_time && rt_has_pending_goal_.load() == false) {
                 RCLCPP_ERROR(get_node()->get_logger(), "Exceeded goal_time_tolerance: holding position...");
 
                 traj_msg_external_point_ptr_.reset();

--- a/eli_cs_robot_driver/config/elite_cs_controllers.yaml
+++ b/eli_cs_robot_driver/config/elite_cs_controllers.yaml
@@ -12,8 +12,8 @@ controller_manager:
     joint_trajectory_controller:
       type: joint_trajectory_controller/JointTrajectoryController
 
-    servo_controller:
-      type: joint_trajectory_controller/JointTrajectoryController
+    joint_velocity_controller:
+      type: joint_velocity_controller/JointVelocityController
 
     forward_velocity_controller:
       type: velocity_controllers/JointGroupVelocityController
@@ -38,16 +38,8 @@ controller_manager:
 
 velocity_force_controller:
   ros__parameters:
-    # Joints that the controller will control.
-    joints:
-      - $(var tf_prefix)shoulder_pan_joint
-      - $(var tf_prefix)shoulder_lift_joint
-      - $(var tf_prefix)elbow_joint
-      - $(var tf_prefix)wrist_1_joint
-      - $(var tf_prefix)wrist_2_joint
-      - $(var tf_prefix)wrist_3_joint
-    # Base frame of the kinematic chain, for computation of arm kinematics.
-    base_frame: base_link
+    # Since MoveIt Pro 9.0, joints and base_frame are derived from planning_group_name.
+    planning_group_name: cs612_manipulator
     # The tip link of the kinematic chain, i.e. the frame that will be controlled.
     ee_frame: tool0
     # The frame where the force / torque sensor reading is given.
@@ -105,8 +97,6 @@ velocity_force_controller:
 joint_trajectory_admittance_controller:
   ros__parameters:
     planning_group_name: cs612_manipulator
-    # Specifies the base link of the kinematic chain. Must exist in the robot description.
-    base_frame: base_link
     # Specifies the frame/link name of the force torque sensor. Must exist in the robot description.
     sensor_frame: tool0
     # Specifies the frame/link name of the end-effector frame. Must exist in the robot description.
@@ -194,32 +184,28 @@ joint_trajectory_controller:
       $(var tf_prefix)wrist_2_joint: { trajectory: 1.25, goal: 0.1 }
       $(var tf_prefix)wrist_3_joint: { trajectory: 1.25, goal: 0.1 }
 
-servo_controller:
+joint_velocity_controller:
   ros__parameters:
-    joints:
-      - $(var tf_prefix)shoulder_pan_joint
-      - $(var tf_prefix)shoulder_lift_joint
-      - $(var tf_prefix)elbow_joint
-      - $(var tf_prefix)wrist_1_joint
-      - $(var tf_prefix)wrist_2_joint
-      - $(var tf_prefix)wrist_3_joint
-    command_interfaces:
-      - position
-    state_interfaces:
-      - position
-      - velocity
-    state_publish_rate: 100.0
-    action_monitor_rate: 20.0
-    allow_partial_joints_goal: false
-    constraints:
-      stopped_velocity_tolerance: 0.2
-      goal_time: 0.05
-      $(var tf_prefix)shoulder_pan_joint: { trajectory: 1.25, goal: 0.1 }
-      $(var tf_prefix)shoulder_lift_joint: { trajectory: 1.25, goal: 0.1 }
-      $(var tf_prefix)elbow_joint: { trajectory: 1.25, goal: 0.1 }
-      $(var tf_prefix)wrist_1_joint: { trajectory: 1.25, goal: 0.1 }
-      $(var tf_prefix)wrist_2_joint: { trajectory: 1.25, goal: 0.1 }
-      $(var tf_prefix)wrist_3_joint: { trajectory: 1.25, goal: 0.1 }
+    planning_group_name: cs612_manipulator
+    # Velocity/acceleration limits match this robot's velocity_force_controller values.
+    max_joint_velocity:
+      - 0.524
+      - 0.524
+      - 0.524
+      - 1.047
+      - 1.047
+      - 1.047
+    max_joint_acceleration:
+      - 0.524
+      - 0.524
+      - 0.524
+      - 0.524
+      - 0.524
+      - 0.524
+    command_interfaces: ["position"]
+    joint_limit_position_tolerance: 0.02
+    command_timeout: 0.2
+    state_publish_rate: 20
 
 forward_velocity_controller:
   ros__parameters:


### PR DESCRIPTION
## Summary

- align controller code and configuration with MoveIt Pro 9
- update generated-parameter include paths for current controller APIs
- preserve the current RT-memory, controller, and collision-model work on feature/moveit_pro

## Validation

- merged locally without conflicts
- git diff --check

Related to https://linear.app/clean-botix/issue/SW-1208